### PR TITLE
Added `sudo` property

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -44,6 +44,10 @@ declare type Params = {
      */
     copy?: Map<string, string>;
     /**
+     * (optional) If set to true, the AppImage will run only with root privileges
+     */
+    sudo?: boolean;
+    /**
      * Output AppImage path
      */
     output?: string;

--- a/dist/index.js
+++ b/dist/index.js
@@ -71,7 +71,7 @@ class Bundler {
                 categories: this.params.desktop.categories
             }));
             console.log('Creating AppRun file...');
-            fs.writeFileSync(path.join(this.appDir, 'AppRun'), AppRun_js_1.default.generate(`${this.params.binary.name}`));
+            fs.writeFileSync(path.join(this.appDir, 'AppRun'), AppRun_js_1.default.generate(`${this.params.binary.name}`, this.params.sudo));
             fs.chmodSync(path.join(this.appDir, 'AppRun'), 0o755);
             console.log('Executing LinuxDeploy...');
             let additionalOptions = [];

--- a/dist/lib/AppRun.d.ts
+++ b/dist/lib/AppRun.d.ts
@@ -1,3 +1,3 @@
 export default class AppRun {
-    static generate(binary: string): string;
+    static generate(binary: string, sudo?: boolean): string;
 }

--- a/dist/lib/AppRun.js
+++ b/dist/lib/AppRun.js
@@ -1,10 +1,19 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 class AppRun {
-    static generate(binary) {
+    static generate(binary, sudo) {
+        const sudo_commands = [
+            'SELF=$(readlink -f "$0")',
+            'HERE=${SELF%/*}',
+            'if [ "$EUID" -ne 0 ]',
+            '  then echo "It requires root permissions to execute the file."',
+            '  exit',
+            'fi'
+        ];
         return [
             '#!/bin/bash',
             '',
+            `${sudo ? sudo_commands.join('\n') : ''}`,
             'if [ -z "$APPDIR" ] ; then',
             '   path="$(dirname "$(readlink -f "${THIS}")")"',
             '   while [[ "$path" != "" && ! -e "$path/$1" ]]; do',

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,11 @@ type Params = {
     copy?: Map<string, string>;
 
     /**
+     * (optional) If set to true, the AppImage will run only with root privileges
+     */
+    sudo?: boolean;
+
+    /**
      * Output AppImage path
      */
     output?: string;
@@ -131,7 +136,7 @@ export class Bundler
 
             console.log('Creating AppRun file...');
 
-            fs.writeFileSync(path.join(this.appDir, 'AppRun'), AppRun.generate(`${this.params.binary.name}`));
+            fs.writeFileSync(path.join(this.appDir, 'AppRun'), AppRun.generate(`${this.params.binary.name}`, this.params.sudo));
             fs.chmodSync(path.join(this.appDir, 'AppRun'), 0o755);
 
             console.log('Executing LinuxDeploy...');

--- a/src/lib/AppRun.ts
+++ b/src/lib/AppRun.ts
@@ -1,10 +1,20 @@
 export default class AppRun
 {
-    public static generate(binary: string): string
+    public static generate(binary: string, sudo?: boolean): string
     {
+        const sudo_commands = [
+            'SELF=$(readlink -f "$0")',
+            'HERE=${SELF%/*}',
+            'if [ "$EUID" -ne 0 ]',
+            '  then echo "It requires root permissions to execute the file."',
+            '  exit',
+            'fi'
+        ];
+
         return [
             '#!/bin/bash',
             '',
+            `${sudo ? sudo_commands.join('\n') : ''}`,
             'if [ -z "$APPDIR" ] ; then',
             '   path="$(dirname "$(readlink -f "${THIS}")")"',
             '   while [[ "$path" != "" && ! -e "$path/$1" ]]; do',


### PR DESCRIPTION
**What is it?**

- [ ]  Bugfix (user facing)
- [x]  Feature (user facing)
- [ ]  Codebase improvement (dev facing)
- [ ]  Meta improvement to the project (dev facing)

**Description of the changes in your PR**
I added the `sudo` property to make the AppImage run with root privileges only. It might be useful when the Neutralino project needs to (re-)execute extensions, system commands and/or third-party apps installed which require those permissions as well.